### PR TITLE
adaptive_image.module typo fix for 500 internal server error Update README.md with new maintainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ INSTALLATION
 MAINTAINERS
 -----------
 
-- seeking maintainers
+- [drybro](https://github.com/drybro/)
 
 
 CREDITS

--- a/adaptive_image.module
+++ b/adaptive_image.module
@@ -246,7 +246,7 @@ function adaptive_image_resolution($resolutions) {
               }
             }
             // now apply the multiplier
-            $resolution = $resolution * pixel_density;
+            $resolution = $resolution * $pixel_density;
           }
           // the required image fits into the existing breakpoints in $resolutions
           else {


### PR DESCRIPTION
Add $ prefix to pixel_density so it is recognized as a variable instead of an undefined constant.

Fixes https://github.com/backdrop-contrib/adaptive_image/issues/2 